### PR TITLE
Tests using alloy

### DIFF
--- a/testing/Cargo.lock
+++ b/testing/Cargo.lock
@@ -58,6 +58,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-dyn-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b954c58532b0b327fa0cc7ce7d1a6b5a1554639620d99d812e27443cb486c7"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa 1.0.5",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe46acf61ad5bd7a5c21839bb2526358382fb8a6526f7ba393bdf593e2ae43f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,14 +121,23 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7720130c58db647103587b0c39aad4e669eea261e256040301d6c7983fdbb461"
 dependencies = [
+ "alloy-json-abi",
  "dunce",
  "heck",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn 2.0.37",
  "syn-solidity",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "627a32998aee7a7eedd351e9b6d4cacef9426935219a3a61befa332db1be5ca3"
 
 [[package]]
 name = "alloy-sol-types"
@@ -496,6 +533,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "cbor-data"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1165c64320670370b3d45dbf666b6f815223785f4b2def266fd25ba23458cd"
+dependencies = [
+ "base64",
+ "half",
+ "smallvec",
 ]
 
 [[package]]
@@ -2119,6 +2167,12 @@ dependencies = [
  "rand_xorshift",
  "subtle",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -3810,10 +3864,14 @@ dependencies = [
 name = "testing"
 version = "0.1.0"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "alloy-primitives",
+ "alloy-sol-macro",
  "alloy-sol-types",
  "anyhow",
  "bls-signatures 0.13.0",
+ "cbor-data",
  "cid",
  "fil_actor_datacap",
  "fil_actor_eam",
@@ -3835,6 +3893,7 @@ dependencies = [
  "prettytable-rs",
  "rand_core",
  "serde",
+ "serde_json",
  "serde_tuple",
  "wabt",
 ]

--- a/testing/Cargo.lock
+++ b/testing/Cargo.lock
@@ -58,6 +58,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if 1.0.0",
+ "const-hex",
+ "derive_more",
+ "hex-literal 0.4.1",
+ "itoa 1.0.5",
+ "proptest",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f938f00332d63a5b0ac687bd6f46d03884638948921d9f8b50c59563d421ae25"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bytes",
+ "smol_str",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7720130c58db647103587b0c39aad4e669eea261e256040301d6c7983fdbb461"
+dependencies = [
+ "dunce",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa7c9a4354b1ff9f1c85adf22802af046e20e4bb55e19b9dc6ca8cbc6f7f4e5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,7 +152,7 @@ checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -172,6 +229,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -401,9 +473,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
 ]
@@ -527,6 +599,18 @@ dependencies = [
  "pathdiff",
  "serde",
  "toml",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08849ed393c907c90016652a01465a12d86361cd38ad2a7de026c56a520cc259"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -822,7 +906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -846,7 +930,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -857,7 +941,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -883,7 +967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -894,7 +978,7 @@ checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -915,7 +999,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -925,7 +1009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -938,7 +1022,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1025,6 +1109,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ec-gpu"
@@ -1119,7 +1209,7 @@ checksum = "5109f6bc9cd57feda665da326f3f6c57e0498c8fe9f7d12d7b8abc96719ca91b"
 dependencies = [
  "execute-command-tokens",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1202,7 +1292,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 3.0.0-alpha.17",
- "hex-literal",
+ "hex-literal 0.3.4",
  "log",
  "multihash",
  "num-derive",
@@ -1231,7 +1321,7 @@ dependencies = [
  "fvm_ipld_kamt",
  "fvm_shared 3.0.0-alpha.17",
  "hex",
- "hex-literal",
+ "hex-literal 0.3.4",
  "impl-serde",
  "lazy_static",
  "log",
@@ -1498,7 +1588,7 @@ dependencies = [
  "frc42_hasher",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1596,7 +1686,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2076,6 +2166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hkdf"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2394,12 @@ dependencies = [
  "serde",
  "thiserror",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsecp256k1"
@@ -2533,7 +2635,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -2625,7 +2727,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2669,6 +2771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2865,7 +2968,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -2882,11 +2985,31 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2899,10 +3022,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.23"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -3064,6 +3193,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95294d6e3a6192f3aabf91c38f56505a625aa495533442744185a36d75a790c4"
+dependencies = [
+ "proptest",
+ "rand",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+
+[[package]]
 name = "rust-gpu-tools"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,6 +3300,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,7 +3364,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3237,7 +3398,7 @@ checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3258,7 +3419,7 @@ checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3352,6 +3513,15 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "spin"
@@ -3522,7 +3692,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3556,6 +3726,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397f229dc34c7b8231b6ef85502f9ca4e3425b8625e6d403bb74779e6b1917b5"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,7 +3756,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -3617,6 +3810,8 @@ dependencies = [
 name = "testing"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "bls-signatures 0.13.0",
  "cid",
@@ -3661,7 +3856,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3671,6 +3866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3714,6 +3918,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
@@ -3766,6 +3976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +4008,15 @@ dependencies = [
  "cc",
  "cmake",
  "glob 0.2.11",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4184,9 +4409,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
@@ -4199,6 +4424,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -36,4 +36,4 @@ frc46_token = { version = "4.0.0" }
 frc42_dispatch = { version = "3.0.1-alpha.1" }
 
 alloy-sol-types = "0.3.2"
-alloy-primitives = "0.3.2"
+alloy-primitives = "0.3.3"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -37,3 +37,9 @@ frc42_dispatch = { version = "3.0.1-alpha.1" }
 
 alloy-sol-types = "0.3.2"
 alloy-primitives = "0.3.3"
+alloy-json-abi = "0.3.2"
+alloy-dyn-abi = "0.3.2"
+alloy-sol-macro = { version = "0.3.2", features = ["json"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+
+cbor-data = "0.8.15"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -34,3 +34,6 @@ fil_actor_evm = { version = "10.0.0-alpha.1", git = "https://github.com/filecoin
 fvm_actor_utils = { version = "4.0.0" }
 frc46_token = { version = "4.0.0" }
 frc42_dispatch = { version = "3.0.1-alpha.1" }
+
+alloy-sol-types = "0.3.2"
+alloy-primitives = "0.3.2"

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -9,7 +9,7 @@ extern crate prettytable;
 
 pub mod helpers;
 pub mod setup;
-
+pub mod types;
 
 pub type GasResult = Vec<(String, i64)>;
 

--- a/testing/src/types.rs
+++ b/testing/src/types.rs
@@ -7,6 +7,7 @@ sol! {
     }
 
     type FilActorId is uint64;
+    type Amount is uint256;
 }
 
 

--- a/testing/src/types.rs
+++ b/testing/src/types.rs
@@ -1,55 +1,77 @@
-use alloy_sol_types::sol;
+use alloy_sol_types::{sol, SolCall};
+use alloy_sol_types::SolStruct;
 
-
-// MarketTypes.PublishStorageDealsParams
 sol! {
-    struct Cid {
-        bytes data;
-    }
-
-    struct DealLabel {
-        bytes data;
-        bool isString;
-    }
-
     struct FilAddress {
         bytes data;
     }
 
-    struct BigInt {
-        bytes val;
-        bool neg;
-    }
-
-    struct WithdrawBalanceParams {
-        FilAddress provider_or_client;
-        BigInt tokenAmount;
-    }
+    type FilActorId is uint64;
 }
 
-sol! {
-    type ChainEpoch is int64;
 
-    struct DealProposal {
-        Cid piece_cid;
-        uint64 piece_size;
-        bool verified_deal;
-        FilAddress client;
-        FilAddress provider;
-        DealLabel label;
-        ChainEpoch start_epoch;
-        ChainEpoch end_epoch;
-        BigInt storage_price_per_epoch;
-        BigInt provider_collateral;
-        BigInt client_collateral;
-    }
+// CommonTypes.FilAddress
+// CommonTypes.FilActorId
+// sol! {
+//     struct Cid {
+//         bytes data;
+//     }
+// }
 
-    struct ClientDealProposal {
-        DealProposal proposal;
-        bytes client_signature;
-    }
+// sol! {
+//     struct DealLabel {
+//         bytes data;
+//         bool isString;
+//     }
+// }
 
-    struct PublishStorageDealsParams {
-        ClientDealProposal[] deals;
-    }
-}
+// sol! {
+//     struct FilAddress {
+//         bytes data;
+//     }
+// }
+
+// sol! {
+//     struct BigInt {
+//         bytes val;
+//         bool neg;
+//     }
+// }
+
+// sol! {
+//     struct WithdrawBalanceParams {
+//         FilAddress provider_or_client;
+//         BigInt tokenAmount;
+//     }
+// }
+
+// sol! {
+//     type ChainEpoch is int64;
+
+//     struct DealProposal {
+//         Cid piece_cid;
+//         uint64 piece_size;
+//         bool verified_deal;
+//         FilAddress client;
+//         FilAddress provider;
+//         DealLabel label;
+//         ChainEpoch start_epoch;
+//         ChainEpoch end_epoch;
+//         BigInt storage_price_per_epoch;
+//         BigInt provider_collateral;
+//         BigInt client_collateral;
+//     }
+// }
+
+// sol! {
+//     struct ClientDealProposal {
+//         DealProposal proposal;
+//         bytes client_signature;
+//     }
+// }
+
+// sol! {
+//     struct PublishStorageDealsParams {
+//         ClientDealProposal[] deals;
+//     }
+// }

--- a/testing/src/types.rs
+++ b/testing/src/types.rs
@@ -1,0 +1,55 @@
+use alloy_sol_types::sol;
+
+
+// MarketTypes.PublishStorageDealsParams
+sol! {
+    struct Cid {
+        bytes data;
+    }
+
+    struct DealLabel {
+        bytes data;
+        bool isString;
+    }
+
+    struct FilAddress {
+        bytes data;
+    }
+
+    struct BigInt {
+        bytes val;
+        bool neg;
+    }
+
+    struct WithdrawBalanceParams {
+        FilAddress provider_or_client;
+        BigInt tokenAmount;
+    }
+}
+
+sol! {
+    type ChainEpoch is int64;
+
+    struct DealProposal {
+        Cid piece_cid;
+        uint64 piece_size;
+        bool verified_deal;
+        FilAddress client;
+        FilAddress provider;
+        DealLabel label;
+        ChainEpoch start_epoch;
+        ChainEpoch end_epoch;
+        BigInt storage_price_per_epoch;
+        BigInt provider_collateral;
+        BigInt client_collateral;
+    }
+
+    struct ClientDealProposal {
+        DealProposal proposal;
+        bytes client_signature;
+    }
+
+    struct PublishStorageDealsParams {
+        ClientDealProposal[] deals;
+    }
+}

--- a/testing/tests/market.rs
+++ b/testing/tests/market.rs
@@ -33,6 +33,9 @@ use testing::parse_gas;
 use testing::setup;
 use testing::GasResult;
 
+use testing::types;
+use alloy_primitives;
+
 const WASM_COMPILED_PATH: &str = "../build/v0.8/tests/MarketApiTest.bin";
 
 #[derive(SerdeSerialize, SerdeDeserialize)]
@@ -449,6 +452,66 @@ fn market_tests() {
         ..Message::default()
     };*/
 
+    // PLS
+            // [[[[
+            // ["0x0181E203922020B51BCC94BB0977C984C093770289DEA4E83EF08C355145D412C6673E06152A09"],
+            // 8388608,
+            // false,
+            // ["0x0390A40613DFB06445DFC3759EC22146D66B832AFE57B4AC441E5209D154131B1540E937CB837831855553E17EEFEEEED1"],
+            // ["0x0068"],
+            // ["0x6d41584367354149673859425862466a7464427931695a6a704459417752537430656c474c463547765471756c4569693156634d", true],
+            // 25245,
+            // 545150,
+            // ["0x01001D1BF800", false],
+            // ["0x038D7EA4C68000", false],
+            // ["0x038D7EA4C68000", false]],
+            // "0x02B7E4AD239896D5DF3491AFE01F9A6F9D5C4A1E59C16E6B386CE16797C00A1224D5ABB8EFE0EDC7B052FC0AB5772BA4DA10C064537320FEFCADA4167017508D882207B23DD457966DAF21393710A26CC5509AC079EC9A0846028B279435BD5F22" ]]]
+
+    let b = alloy_primitives::Bytes::from_static(b"hello");
+    let a = alloy_primitives::Bytes::from_static(b"090A0B0C");
+    let c = alloy_primitives::Bytes::from_static(b"0181E203922020B51BCC94BB0977C984C093770289DEA4E83EF08C355145D412C6673E06152A09");
+
+    let piece_cid = types::Cid {
+        data: alloy_primitives::Bytes::from_static(
+        b"0181E203922020B51BCC94BB0977C984C093770289DEA4E83EF08C355145D412C6673E06152A09"
+        ).to_vec()
+    };
+
+    let deal_proposal = types::DealProposal {
+        piece_cid: types::Cid {
+            data: alloy_primitives::Bytes::from_static(b"0181E203922020B51BCC94BB0977C984C093770289DEA4E83EF08C355145D412C6673E06152A09").to_vec()
+        },
+        piece_size: 8388608,
+        verified_deal: false,
+        client: types::FilAddress {
+            data: alloy_primitives::Bytes::from_static(b"0390A40613DFB06445DFC3759EC22146D66B832AFE57B4AC441E5209D154131B1540E937CB837831855553E17EEFEEEED1").to_vec()
+        },
+        provider: types::FilAddress {
+            data: alloy_primitives::Bytes::from_static(b"0068").to_vec()
+        },
+        label: types::DealLabel {
+            data: alloy_primitives::Bytes::from_static(b"6d41584367354149673859425862466a7464427931695a6a704459417752537430656c474c463547765471756c4569693156634d").to_vec(),
+            isString: true
+        },
+        // start_epoch: alloy_primitives::I64::from(25245),
+        // end_epoch: alloy_primitives::I64::from(545150),
+        start_epoch: "25245".parse().unwrap(),
+        end_epoch: "545150".parse().unwrap(),
+        storage_price_per_epoch: types::BigInt {
+            val: alloy_primitives::Bytes::from_static(b"01001D1BF800").to_vec(),
+            neg: false
+        },
+        provider_collateral: types::BigInt {
+            val: alloy_primitives::Bytes::from_static(b"038D7EA4C68000").to_vec(),
+            neg: false
+        },
+        client_collateral: types::BigInt {
+            val: alloy_primitives::Bytes::from_static(b"038D7EA4C68000").to_vec(),
+            neg: false
+        }
+    };
+
+    let abi_encoded = types::DealProposal::encode(&deal_proposal);
     println!("Calling `publish_storage_deals`");
 
     let message = Message {


### PR DESCRIPTION
Encode function params using `alloy_sol_types` and `alloy_primitives`.

1. Create types based on solidity structs
2. Load them in test file and encode params for tests

Still in progress, tests don't pass.